### PR TITLE
Hopefully makes this thing work with ALL Android devices.... :/

### DIFF
--- a/lib/Canvas.js
+++ b/lib/Canvas.js
@@ -30,7 +30,10 @@ var Canvas = createReactClass({
                     automaticallyAdjustContentInsets={false}
                     scalesPageToFit={Platform.OS === 'android'}
                     contentInset={{top: 0, right: 0, bottom: 0, left: 0}}
-                    source={{html: htmlString}}
+                    source={{
+                        baseUrl: ' ',
+                        html: htmlString
+                    }}
                     opaque={false}
                     underlayColor={'transparent'}
                     style={this.props.style}


### PR DESCRIPTION
Various Android devices were showing a blank white screen instead of a barcode. After a long Googling session, as well as some blood sweat and tears, we noticed that adding `baseUrl: ' '` fixed our problem!